### PR TITLE
Add ext-bcmath extension as a dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=8.0",
         "ext-hash": "*",
-        "ext-bcmath": "*"
+        "ext-bcmath": "*",
+        "ext-soap": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=8.0",
-        "ext-hash": "*"
+        "ext-hash": "*",
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"


### PR DESCRIPTION
Si esta extensión no aparece explícitamente en composer require y el servidor no la tiene instalada, da error. Ejemplo, en RegistroAlta::addDesglose()